### PR TITLE
Output folder defaults to sourcefolder if not set

### DIFF
--- a/Batch HDR.jsx
+++ b/Batch HDR.jsx
@@ -83,8 +83,9 @@ function main()
 
         var numberOfFiles = files.length;
 
-        /* convert numberOfFiles to a string to make sure zeropadding is high enough to cover all files */
-        var numberOfFilesStr = "" + numberOfFiles;
+        /* convert numberOfFiles to a string to make sure zeropaddingis high enough to cover all files */
+
+        var numberOfFilesStr = "" + (numberOfFiles / numberOfBrackets);
         if (zeroPadding > 0 && zeroPadding < numberOfFilesStr.length)
         {
             zeroPadding = numberOfFilesStr.length;


### PR DESCRIPTION
Hiya, thanks for a great little script for doing this kind of magic.
I added a few lines so that the destination folder will default to the same folder as the sourcefolder when selecting the sourcefolder :-)
